### PR TITLE
Speedtest Chainer vs. Pytorch implementation from fb research

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
   - pip install .
 
 script:
-  - pip install flake8 pytest
+  - pip install hacking pytest
   - flake8 .
   - pytest -v tests -m 'not gpu'
 

--- a/chainer_mask_rcnn/datasets/coco.py
+++ b/chainer_mask_rcnn/datasets/coco.py
@@ -36,7 +36,7 @@ class COCOInstanceSegmentationDataset(chainer.dataset.DatasetMixin):
              'https://dl.dropboxusercontent.com/s/o43o90bna78omob/instances_minival2014.json.zip',  # NOQA
              'annotations/instances_minival2014.json.zip'),
             ('f72ed643338e184978e8228948972e84',
-             'https://dl.dropboxusercontent.com/s/s3tw5zcg7395368/instances_valminusminival2014.json.zip',
+             'https://dl.dropboxusercontent.com/s/s3tw5zcg7395368/instances_valminusminival2014.json.zip',  # NOQA
              'annotations/instances_valminusminival2014.json.zip'),
         ]
         for md5, url, basename in data:

--- a/examples/coco/README.md
+++ b/examples/coco/README.md
@@ -43,3 +43,42 @@ See [here](https://drive.google.com/open?id=1Dfpc2Dd7_hh9ZsgfbDnuVG4xUnQFBksa) f
 
 <img src=".readme/R-50-C4_x1_caffe2_result_33823288584_1d21cf0a26_k.jpg" width="48%" /> <img src=".readme/R-50-C4_x1_caffe2_to_chainer_result_33823288584_1d21cf0a26_k.jpg" width="48%" />  
 *Fig 1. Inference results: Caffe2 (left), Chainer (right).*
+
+
+## Speed test (vs. PyTorch implementation)
+
+Configuration:
+
+- GTX 1080Ti (used also on monitor)
+- CUDA 8.0.61
+- CUDNN 5.1.10
+- PyTorch 1.0.0.dev20181024 (with `conda install pytorch-nightly cuda80 -c pytorch`)
+- Chainer 5.0.0, Cupy 5.0.0 (with `pip install chainer cupy-cuda80`)
+
+- CPU -> GPU communication of input.
+- BBox prediction and suppression.
+- Mask prediction for remaining bboxes (nms thresh: 0.5, score thresh: 0.7).
+- GPU -> CPU communication of output.
+
+```bash
+# Chainer implementation (this repo)
+% pwd
+/home/wkentaro/chainer-mask-rcnn/examples/coco
+% ./speedtest.py --gpu 0 --times 10
+==> Benchmark: gpu=0, times=10
+==> Image file: https://raw.githubusercontent.com/facebookresearch/Detectron/master/demo/33823288584_1d21cf0a26_k.jpg
+==> Testing Mask R-CNN RestNet50-C4 with Chainer
+Elapsed time: 3.09 [s / 10 evals]
+Hz: 3.24 [hz]
+
+# PyTorch implementation (https://github.com/facebookresearch/maskrcnn-benchmark)
+% git clone https://github.com/wkentaro/maskrcnn-benchmark.git -b speedtest_r50_c4  # then install it
+% pwd
+/home/wkentaro/maskrcnn-benchmark/demo
+% ./speedtest.py --gpu 0 --times 10
+==> Benchmark: gpu=0, times=10
+==> Image file: https://raw.githubusercontent.com/facebookresearch/Detectron/master/demo/33823288584_1d21cf0a26_k.jpg
+==> Testing Mask R-CNN ResNet-C4 with PyTorch
+Elapsed time: 3.44 [s / 10 evals]
+Hz: 2.91 [hz]
+```

--- a/examples/coco/speedtest.py
+++ b/examples/coco/speedtest.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+
+import argparse
+import os.path as osp
+import time
+
+import chainer
+import chainer_mask_rcnn
+import numpy as np
+import six
+import skimage.io
+import yaml
+
+
+def bench_chainer(img_file, gpu, times):
+    print('==> Testing Mask R-CNN RestNet50-C4 with Chainer')
+    chainer.cuda.get_device(gpu).use()
+
+    chainer.config.train = False
+    chainer.config.enable_backprop = False
+
+    log_dir = 'logs/R-50-C4_x1_caffe2_to_chainer'
+    with open(osp.join(log_dir, 'params.yaml')) as f:
+        params = yaml.load(f)
+    pretrained_model = osp.join(log_dir, 'snapshot_model.npz')
+
+    assert params['model'] == 'resnet50'
+    assert len(params['class_names']) == 80
+
+    model = chainer_mask_rcnn.models.MaskRCNNResNet(
+        n_layers=50,
+        n_fg_class=80,
+        pretrained_model=pretrained_model,
+        anchor_scales=params['anchor_scales'],
+        mean=params['mean'],
+        min_size=params['min_size'],
+        max_size=params['max_size'],
+        roi_size=params['roi_size'],
+    )
+    model.score_thresh = 0.7
+    chainer.cuda.get_device_from_id(gpu).use()
+    model.to_gpu()
+
+    img = skimage.io.imread(img_file)
+    img_chw = img.transpose(2, 0, 1)
+
+    for i in six.moves.range(5):
+        model.predict([img_chw])
+    chainer.cuda.Stream().synchronize()
+    t_start = time.time()
+    for i in six.moves.range(times):
+        model.predict([img_chw])
+    chainer.cuda.Stream().synchronize()
+    elapsed_time = time.time() - t_start
+
+    print('Elapsed time: %.2f [s / %d evals]' % (elapsed_time, times))
+    print('Hz: %.2f [hz]' % (times / elapsed_time))
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument('--gpu', type=int, default=0, help='gpu id')
+    parser.add_argument(
+        '--times', type=int, default=100, help='number of times of inference'
+    )
+    args = parser.parse_args()
+
+    img_file = 'https://raw.githubusercontent.com/facebookresearch/Detectron/master/demo/33823288584_1d21cf0a26_k.jpg'  # NOQA
+
+    print('==> Benchmark: gpu=%d, times=%d' % (args.gpu, args.times))
+    print('==> Image file: %s' % img_file)
+    bench_chainer(img_file, args.gpu, args.times)
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/coco/speedtest.py
+++ b/examples/coco/speedtest.py
@@ -6,7 +6,6 @@ import time
 
 import chainer
 import chainer_mask_rcnn
-import numpy as np
 import six
 import skimage.io
 import yaml


### PR DESCRIPTION
## Speed test (vs. PyTorch implementation)

Configuration:

- GTX 1080Ti (used also on monitor)
- CUDA 8.0.61
- CUDNN 5.1.10
- PyTorch 1.0.0.dev20181024 (with `conda install pytorch-nightly cuda80 -c pytorch`)
- Chainer 5.0.0, Cupy 5.0.0 (with `pip install chainer cupy-cuda80`)

- CPU -> GPU communication of input.
- BBox prediction and suppression.
- Mask prediction for remaining bboxes (nms thresh: 0.5, score thresh: 0.7).
- GPU -> CPU communication of output.

```bash
# Chainer implementation (this repo)
% pwd
/home/wkentaro/chainer-mask-rcnn/examples/coco
% ./speedtest.py --gpu 0 --times 10
==> Benchmark: gpu=0, times=10
==> Image file: https://raw.githubusercontent.com/facebookresearch/Detectron/master/demo/33823288584_1d21cf0a26_k.jpg
==> Testing Mask R-CNN RestNet50-C4 with Chainer
Elapsed time: 3.09 [s / 10 evals]
Hz: 3.24 [hz]

# PyTorch implementation (https://github.com/facebookresearch/maskrcnn-benchmark)
% git clone https://github.com/wkentaro/maskrcnn-benchmark.git -b speedtest_r50_c4  # then install it
% pwd
/home/wkentaro/maskrcnn-benchmark/demo
% ./speedtest.py --gpu 0 --times 10
==> Benchmark: gpu=0, times=10
==> Image file: https://raw.githubusercontent.com/facebookresearch/Detectron/master/demo/33823288584_1d21cf0a26_k.jpg
==> Testing Mask R-CNN ResNet-C4 with PyTorch
Elapsed time: 3.44 [s / 10 evals]
Hz: 2.91 [hz]
```
