### PR TITLE
Enable to work print func of setup.py in Python 2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import distutils.spawn
 import shlex
 import subprocess


### PR DESCRIPTION
`pip install chainer-mask-rcnn==0.5.16` fails due to the following error:
```
Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-PcxpPN/chainer-mask-rcnn/setup.py", line 19
        file=sys.stderr,
            ^
    SyntaxError: invalid syntax
```
This PR avoids this syntax error.

FYI: this error also occurred on travis.
https://travis-ci.com/wkentaro/chainer-mask-rcnn/jobs/167810300